### PR TITLE
Only add Combine Support if Module can be Imported

### DIFF
--- a/Sources/SwiftCoroutine/Combine/CoFuture+Combine.swift
+++ b/Sources/SwiftCoroutine/Combine/CoFuture+Combine.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Alex Belozierov. All rights reserved.
 //
 
+#if canImport(Combine)
 import Combine
 
 @available(OSX 10.15, iOS 13.0, *)
@@ -35,3 +36,4 @@ extension Subscriber {
     }
     
 }
+#endif

--- a/Sources/SwiftCoroutine/Combine/CoPromise+Combine.swift
+++ b/Sources/SwiftCoroutine/Combine/CoPromise+Combine.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Alex Belozierov. All rights reserved.
 //
 
+#if canImport(Combine)
 import Combine
 
 @available(OSX 10.15, iOS 13.0, *)
@@ -23,3 +24,4 @@ extension CoPromise: Subject {
     }
     
 }
+#endif

--- a/Sources/SwiftCoroutine/Combine/CoSubscription.swift
+++ b/Sources/SwiftCoroutine/Combine/CoSubscription.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Alex Belozierov. All rights reserved.
 //
 
+#if canImport(Combine)
 import Combine
 
 @available(OSX 10.15, iOS 13.0, *)
@@ -38,3 +39,4 @@ extension CoSubscription: Hashable {
     }
     
 }
+#endif

--- a/Sources/SwiftCoroutine/Combine/Dispatcher+Scheduler.swift
+++ b/Sources/SwiftCoroutine/Combine/Dispatcher+Scheduler.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Alex Belozierov. All rights reserved.
 //
 
+#if canImport(Combine)
 import Combine
 
 @available(OSX 10.15, iOS 13.0, *)
@@ -20,3 +21,4 @@ extension Coroutine.Dispatcher {
     }
     
 }
+#endif

--- a/Sources/SwiftCoroutine/Combine/Publisher+Extensions.swift
+++ b/Sources/SwiftCoroutine/Combine/Publisher+Extensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Alex Belozierov. All rights reserved.
 //
 
+#if canImport(Combine)
 import Combine
 import Dispatch
 
@@ -26,3 +27,4 @@ extension Publisher {
     }
     
 }
+#endif

--- a/Sources/SwiftCoroutine/Protocols/CoCancellable.swift
+++ b/Sources/SwiftCoroutine/Protocols/CoCancellable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Alex Belozierov. All rights reserved.
 //
 
+#if !canImport(Combine)
+
 import Combine
 
 public protocol CoCancellable: Cancellable, Hashable {
@@ -14,6 +16,17 @@ public protocol CoCancellable: Cancellable, Hashable {
     func cancelUpstream()
     
 }
+
+#else
+
+public protocol CoCancellable: Hashable {
+
+    func cancel()
+    func cancelUpstream()
+
+}
+
+#endif
 
 extension CoCancellable where Self: AnyObject {
     
@@ -47,5 +60,5 @@ final public class AnyCoCancellable: CoCancellable {
     @inlinable public func hash(into hasher: inout Hasher) {
         ObjectIdentifier(self).hash(into: &hasher)
     }
-    
+
 }

--- a/Tests/SwiftCoroutineTests/CombineTests.swift
+++ b/Tests/SwiftCoroutineTests/CombineTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Alex Belozierov. All rights reserved.
 //
 
+#if canImport(Combine)
 import XCTest
 import Combine
 import SwiftCoroutine
@@ -35,3 +36,4 @@ class CombineTests: XCTestCase {
     }
     
 }
+#endif


### PR DESCRIPTION
In theory, this should allow the library to be used on Linux platforms also.